### PR TITLE
Remove debug line from ChangelogController

### DIFF
--- a/src/Http/Controllers/ChangelogController.php
+++ b/src/Http/Controllers/ChangelogController.php
@@ -17,7 +17,6 @@ class ChangelogController extends \App\Http\Controllers\Controller
         }
 
         $changelogMarkdown = file_get_contents($changelogFile);
-        ray($changelogMarkdown);
 
         return (new CommonMarkConverter())->convert($changelogMarkdown);
     }


### PR DESCRIPTION
The ray() debug function was removed from the ChangelogController class. This was likely left in by mistake during a debugging session and is not needed in the production code, thus it has been cleaned up.